### PR TITLE
Support LoadCommand

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string>redApple.icns</string>
+	<string>greenApple.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/LoadCommands.mm
+++ b/LoadCommands.mm
@@ -85,6 +85,7 @@ using namespace std;
         case LC_DYLD_EXPORTS_TRIE:    return @"LC_DYLD_EXPORTS_TRIE";
         case LC_DYLD_CHAINED_FIXUPS:  return @"LC_DYLD_CHAINED_FIXUPS";
         case LC_FILESET_ENTRY:        return @"LC_FILESET_ENTRY";
+        case LC_ATOM_INFO:            return @"LC_ATOM_INFO";
     }
 }
 
@@ -2405,6 +2406,7 @@ using namespace std;
     case LC_DATA_IN_CODE:
     case LC_DYLIB_CODE_SIGN_DRS:
     case LC_LINKER_OPTIMIZATION_HINT:
+    case LC_ATOM_INFO:
     {
       MATCH_STRUCT(linkedit_data_command,location)
       node = [self createLCLinkeditDataNode:parent 


### PR DESCRIPTION
Added support for LC_ATOM_INFO LoadCommand:

![image](https://github.com/user-attachments/assets/3da15978-f080-49e8-9615-472bb6b65dc2)
